### PR TITLE
new spec tuned_adm_active

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -6800,6 +6800,15 @@
                 }
             ]
         },
+        "tuned_adm_active": {
+            "host": [
+                {
+                    "archive_file_name": "/insights_commands/tuned-adm_active",
+                    "command": "/usr/sbin/tuned-adm active",
+                    "pattern": []
+                }
+            ]
+	},
         "uname": {
             "host": [
                 {

--- a/uploader.json
+++ b/uploader.json
@@ -633,6 +633,11 @@
             "symbolic_name": "tuned_adm"
         },
         {
+            "command": "/usr/sbin/tuned-adm active",
+            "pattern": [],
+            "symbolic_name": "tuned_adm_active"
+        },
+        {
             "command": "/bin/uname -a",
             "pattern": [],
             "symbolic_name": "uname"
@@ -6800,7 +6805,7 @@
                 }
             ]
         },
-        "tuned_adm_active": {
+        "tuned-adm_active": {
             "host": [
                 {
                     "archive_file_name": "/insights_commands/tuned-adm_active",


### PR DESCRIPTION
insights_archive.py:    tuned_adm_active = simple_file("insights_commands/tuned-adm_active")
__init__.py:    tuned_adm_active = RegistryPoint()
default.py:    tuned_adm_active = simple_command("/usr/sbin/tuned-adm active")

https://github.com/RedHatInsights/insights-core/pull/1167