### PR TITLE
Add lspci kernel spec and ss tupna spec

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -423,6 +423,11 @@
             "symbolic_name": "lspci"
         },
         {
+            "command": "/sbin/lspci -k",
+            "pattern": [],
+            "symbolic_name": "lspci_kernel"
+        },
+        {
             "command": "/usr/sap/hostctrl/exe/lssap",
             "pattern": [],
             "symbolic_name": "lssap"

--- a/uploader.json
+++ b/uploader.json
@@ -656,6 +656,11 @@
             "symbolic_name": "ss"
         },
         {
+            "command": "/usr/sbin/ss -tupna",
+            "pattern": [],
+            "symbolic_name": "ss_tupna"
+        },
+        {
             "command": "/bin/ls -l /etc/ssh/sshd_config",
             "pattern": [],
             "symbolic_name": "sshd_config_perms"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -423,6 +423,11 @@
             "symbolic_name": "lspci"
         },
         {
+            "command": "/sbin/lspci -k",
+            "pattern": [],
+            "symbolic_name": "lspci_kernel"
+        },
+        {
             "command": "/usr/sap/hostctrl/exe/lssap",
             "pattern": [],
             "symbolic_name": "lssap"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -656,6 +656,11 @@
             "symbolic_name": "ss"
         },
         {
+            "command": "/usr/sbin/ss -tupna",
+            "pattern": [],
+            "symbolic_name": "ss_tupna"
+        },
+        {
             "command": "/bin/ls -l /etc/ssh/sshd_config",
             "pattern": [],
             "symbolic_name": "sshd_config_perms"


### PR DESCRIPTION
* This is an iterim change related to #110 
* This change needs to be merged prior to #110 and will provide interim support for the updated parser in https://github.com/RedHatInsights/insights-core/pull/1283 until that parser has been merged.